### PR TITLE
Added some make functions to update quickly the container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+build_container_local:
+	docker build --tag=${IMAGE}:dev .
+
+run_container_local:
+	docker run -it -e PORT=8000 -p 8080:8000 ${IMAGE}:dev
+
+build_for_production:
+	docker build \
+		--platform linux/amd64 \
+    -t ${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${ARTIFACTSREPO}/${IMAGE}:prod \
+		.
+
+push_image_production:
+	docker push ${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${ARTIFACTSREPO}/${IMAGE}:prod
+
+deploy_to_cloud_run:
+	gcloud run deploy \
+		--image ${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${ARTIFACTSREPO}/${IMAGE}:prod \
+		--memory ${MEMORY} \
+		--region ${GCP_REGION}


### PR DESCRIPTION
Series of Makefile functions designed to streamline and automate the Docker build, push, and deployment process to Google Cloud Run.

build_container_local: Builds a Docker image tagged as dev for local development.
run_container_local: Runs the locally built container, exposing it on port 8080.
build_for_production: Builds a production-ready Docker image for deployment on the linux/amd64 platform.
push_image_production: Pushes the production image to Google Artifact Registry.
deploy_to_cloud_run: Deploys the pushed image to Google Cloud Run with specified memory and region settings.